### PR TITLE
Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mini-blockchain
+# mini-blockchain [![Build Status](https://travis-ci.org/QVDev/mini-blockchain.svg?branch=master)](https://travis-ci.org/QVDev/mini-blockchain)
 Server-run blockchain built from scratch. The blockchain exchanges a fake currency and implements all the defining features of a
 standard blockchain including:
 * SHA-256 hashing for security


### PR DESCRIPTION
Basic travis-ci added.

State is unknown as the badge points to master branch and that has not been build yet.

The purpose is to add tests as wel so it can be tested during development.